### PR TITLE
update SRC_URI to real origin of activemq tar

### DIFF
--- a/net-libs/apache-activemq/apache-activemq-5.5.0.ebuild
+++ b/net-libs/apache-activemq/apache-activemq-5.5.0.ebuild
@@ -6,7 +6,7 @@ inherit versionator java-vm-2 eutils pax-utils
 
 DESCRIPTION="Open Source Messaging"
 HOMEPAGE="http://activemq.apache.org"
-SRC_URI="http://apache.mirroring.de/activemq/apache-activemq/${PV}/${P}-bin.tar.gz"
+SRC_URI="http://archive.apache.org/dist/activemq/apache-activemq/${PV}/${P}-bin.tar.gz"
 
 SLOT="0"
 LICENSE="apache-2"


### PR DESCRIPTION
SRC_URI in activemq ebuild was pointing into a 404. This changes it to the official location on archive.apache.org.
