### PR TITLE
depot-tools: change ESVN_REPO_URI to https

### DIFF
--- a/dev-util/depot-tools/depot-tools-9999.ebuild
+++ b/dev-util/depot-tools/depot-tools-9999.ebuild
@@ -8,7 +8,7 @@ inherit eutils subversion
 DESCRIPTION="Tools for working with Chromium development. Needed for projects published by Google"
 HOMEPAGE="http://dev.chromium.org/developers/how-tos/depottools"
 
-ESVN_REPO_URI="http://src.chromium.org/svn/trunk/tools/depot_tools"
+ESVN_REPO_URI="https://src.chromium.org/svn/trunk/tools/depot_tools"
 
 LICENSE="as-is"
 SLOT="0"


### PR DESCRIPTION
Got

> svn: E170011: Repository moved temporarily to 'https://src.chromium.org/svn/trunk/tools/depot_tools'
